### PR TITLE
Added ifelse -> IF() function mapping

### DIFF
--- a/R/dplyr.r
+++ b/R/dplyr.r
@@ -213,6 +213,9 @@ src_translate_env.src_bigquery <- function(x) {
           dplyr::escape(match), dplyr::escape(replace))
       },
 
+      # Other scalar functions
+      ifelse = dplyr::sql_prefix("IF"),
+
       # stringr equivalents
       str_detect = function(x, match) {
         sprintf("REGEXP_MATCH(%s, %s)", dplyr::escape(x),


### PR DESCRIPTION
This pull request adds `ifelse` function SQL translation.

Google BigQuery has a direct equivalent to R's `ifelse` function which is called `IF`.  
According to [reference](https://cloud.google.com/bigquery/query-reference#otherfunctions), the function is in a category called "Other functions" and accepts 3 arguments just like `ifelse` does.

An example test case is listed below
``` r
library(dplyr)
library(bigrquery)

BILLING_PROJECT <- "<YOUR_BILLING_PROJECT>"
BILLING_DATASET <- "<DATASET_INSIDE_THAT_PROJECT>"

bq <- src_bigquery(BILLING_PROJECT, BILLING_DATASET)

# Upload the test data frame to your project
df <- data.frame(a = 1:100, b = 101:200)
ifelse_test_df <- copy_to(bq, df, name = "ifelse_test_df")

# Perform a simple mutate query with ifelse
ifelse_test_df %>%
  mutate( z = ifelse(a <= 10L, 1L, 0L) ) %>%
  summarise( sum_z = sum(z) ) %>%
  collect
```
The use of function with NAs as one of the arguments requires one to specify the type of NA.

``` r
# Perform a simple mutate query with ifelse and NULLs
ifelse_test_df %>%
  mutate( z = ifelse(a <= 10L, 1L, INTEGER(NULL)) ) %>%
  summarise( sum_z = sum(z) ) %>%
  collect
```
Please note that running the test does require to have a Google Cloud billing project set up already.

Thank you for consideration!