### PR TITLE
Sketch of a credential fetch registration system.

### DIFF
--- a/R/auth.r
+++ b/R/auth.r
@@ -27,15 +27,20 @@ bq_env <- new.env(parent = emptyenv())
 get_access_cred <- function() {
   cred <- bq_env$access_cred
   if (is.null(cred)) {
-    cred <- oauth2.0_token(google, bigqr,
-      scope = c(
-          "https://www.googleapis.com/auth/bigquery",
-          "https://www.googleapis.com/auth/cloud-platform"))
-
-    # Stop if unsuccessful
-    set_access_cred(cred)
+    scopes <- c(
+        "https://www.googleapis.com/auth/bigquery",
+        "https://www.googleapis.com/auth/cloud-platform")
+    for (f in bq_env$credential_fetchers) {
+      cred <- f(google, bigqr, scopes)
+      if (!is.null(cred)) {
+        set_access_cred(cred)
+        break
+      }
+    }
   }
-
+  if(is.null(cred)) {
+    stop("Failed to create OAuth2.0 credentials for executing BigQuery request.")
+  }
   cred
 }
 
@@ -54,3 +59,29 @@ reset_access_cred <- function() {
 get_sig <- function() {
   stop("Deprecated: use get_access_cred directly", call. = FALSE)
 }
+
+#' Add a new method for fetching OAuth2 credentials.
+#'
+#' This function will add a function to the list of default mechanisms used
+#' when fetching credentials. The single argument should be a function
+#' which takes an oauth endpoint, an oauth app, and a list of scopes, and
+#' returns either NULL or a valid token.
+#'
+#' @rdname get_access_cred
+#' @export
+#' @keywords internal
+register_credential_fetcher <- function(f) {
+  fetchers <- c(f, bq_env$credential_fetchers)
+  bq_env$credential_fetchers <- fetchers
+}
+
+#' Set the default mechanism for fetching OAuth2 tokens, namely the
+#' "three-legged OAuth dance" (3LO). This simply asks the user to
+#' authenticate our app via a browser.
+fetch_oauth2_creds <- function(google, bigqr, scopes) {
+  oauth2.0_token(google, bigqr,
+                 scope = c(
+                   "https://www.googleapis.com/auth/bigquery",
+                   "https://www.googleapis.com/auth/cloud-platform"))
+}
+register_credential_fetcher(fetch_oauth2_creds)


### PR DESCRIPTION
This is still quite rough, but it's a stab at trying to support credential
registration in bigrquery (which we'd potentially want to move into httr?).
This would allow us to have packages provide their own credential fetch
mechanisms which get used in the default "get an access token" path; two
important use cases for this:

* For Travis, we could have the travis package simply register a new
  credential mechanism that fetches from the environment. Now travis
  credentials can be used in many packages just by adding a dependency and
  loading it (assuming we add some code in `zzz.R` for travis).

* For systems like AWS EC2 and GCE, there's a notion of credentials associated
  with the machine itself (GCE calls this a service account, I forget if AWS
  uses the same term). We could add a hook (here or in another package)
  to **transparently** use those credentials when available.

Note that this is just a sketch, I'm looking to incite some conversation. There are still questions to be handled (how does one control order being a big one).

Once we get closer, feel free to pick apart how much my R looks like I've been
writing Python all day. :wink: In particular, I clearly modeled this as something I'd use with a decorator in Python; what's the idiomatic way to do that in R?

Adding several folks for conversation: @deflaux @jennybc @hadley @jeroenooms 