### PR TITLE
internal service token support

### DIFF
--- a/R/auth.r
+++ b/R/auth.r
@@ -55,18 +55,10 @@ get_sig <- function() {
   stop("Deprecated: use get_access_cred directly", call. = FALSE)
 }
 
-set_service_token <- function(token_file) {
+# The service_token can be an absolute or relative filename, or JSON text
+set_service_token <- function(service_token) {
 
-  # If the file doesn't exist, jsonlite::fromJSON will attempt to parse
-  # the string literal, which throws a less-than-intuitive error to the
-  # user of bigrquery::set_service_token
-  if (!file.exists(token_file)) {
-    stop("Invalid service token file; file does not exist")
-  }
-
-  # This will throw an error if we don't have permissions to read the
-  # file or if the file contains invalid JSON.
-  service_token <- jsonlite::fromJSON(token_file)
+  service_token <- jsonlite::fromJSON(service_token)
 
   endpoint <- httr::oauth_endpoints("google")
 

--- a/R/auth.r
+++ b/R/auth.r
@@ -54,3 +54,26 @@ reset_access_cred <- function() {
 get_sig <- function() {
   stop("Deprecated: use get_access_cred directly", call. = FALSE)
 }
+
+set_service_token <- function(token_file) {
+
+  # If the file doesn't exist, jsonlite::fromJSON will attempt to parse
+  # the string literal, which throws a less-than-intuitive error to the
+  # user of bigrquery::set_service_token
+  if (!file.exists(token_file)) {
+    stop("Invalid service token file; file does not exist")
+  }
+
+  # This will throw an error if we don't have permissions to read the
+  # file or if the file contains invalid JSON.
+  service_token <- jsonlite::fromJSON(token_file)
+
+  endpoint <- httr::oauth_endpoints("google")
+
+  scope <- "https://www.googleapis.com/auth/bigquery"
+
+  cred <- httr::oauth_service_token(endpoint, service_token, scope)
+
+  set_access_cred(cred)
+}
+


### PR DESCRIPTION
This adds internal support for the service account for use with BigQuery.

```
bigrquery:::set_service_token("/path/to/token.json")
bigrquery::list_projects()
```