### PR TITLE
set default options in .onLoad() instead of .onAttach()

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,4 +1,4 @@
-.onAttach <- function(libname, pkgname) {
+.onLoad <- function(libname, pkgname) {
   op <- options()
   defaults <- list(
     bigquery.quiet = NA


### PR DESCRIPTION
to support is_quiet() when loading package without attaching

Should the option be renamed to `bigrquery.quiet` (now: `bigquery.quiet`)?