### PR TITLE
insert_upload_job() gains create_disposition and write_disposition args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Version 0.1.0.9000
 
+* New arguments `create_disposition` and `write_disposition` to `insert_upload_job()`. (#92, @krlmlr)
+
 * New `format_dataset()` and `format_table()`. (#81, @krlmlr)
 
 * New `list_tabledata_iter()` that allows fetching a table in chunks of varying size. (#77, @krlmlr)

--- a/R/tables.r
+++ b/R/tables.r
@@ -100,12 +100,14 @@ merge_table_references <- function(partial, complete) {
 #' @param project project ID to use for the copy job. defaults to the project of
 #'   the destination table.
 #' @param create_disposition behavior for table creation if the destination
-#'   already exists. defaults to \code{CREATE_IF_NEEDED}; see
-#'   \url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.createDisposition}
+#'   already exists. defaults to \code{"CREATE_IF_NEEDED"},
+#'   the only other supported value is \code{"CREATE_NEVER"}; see
+#'   \href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.createDisposition}{the API documentation}
 #'   for more information
 #' @param write_disposition behavior for writing data if the destination already
-#'   exists. defaults to \code{WRITE_EMPTY}; see
-#'   \url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.writeDisposition}
+#'   exists. defaults to \code{"WRITE_EMPTY"}, other possible values are
+#'   \code{"WRITE_TRUNCATE"} and \code{"WRITE_APPEND"}; see
+#'   \href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.writeDisposition}{the API documentation}
 #'   for more information
 #' @seealso API documentation:
 #'   \url{https://cloud.google.com/bigquery/docs/tables#copyingtable}

--- a/R/upload.r
+++ b/R/upload.r
@@ -7,7 +7,16 @@
 #' @param table name of table to insert values into
 #' @param values data frame of data to upload
 #' @param billing project ID to use for billing
-#' @inheritParams copy_table
+#' @param create_disposition behavior for table creation if the destination
+#'   already exists. defaults to \code{"CREATE_IF_NEEDED"},
+#'   the only other supported value is \code{"CREATE_NEVER"}; see
+#'   \href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.createDisposition}{the API documentation}
+#'   for more information
+#' @param write_disposition behavior for writing data if the destination already
+#'   exists. defaults to \code{"WRITE_APPEND"}, other possible values are
+#'   \code{"WRITE_TRUNCATE"} and \code{"WRITE_EMPTY"}; see
+#'   \href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.writeDisposition}{the API documentation}
+#'   for more information
 #' @seealso Google API documentation:
 #' \url{https://developers.google.com/bigquery/loading-data-into-bigquery#loaddatapostrequest}
 #' @family jobs

--- a/R/upload.r
+++ b/R/upload.r
@@ -7,6 +7,7 @@
 #' @param table name of table to insert values into
 #' @param values data frame of data to upload
 #' @param billing project ID to use for billing
+#' @inheritParams copy_table
 #' @seealso Google API documentation:
 #' \url{https://developers.google.com/bigquery/loading-data-into-bigquery#loaddatapostrequest}
 #' @family jobs
@@ -20,7 +21,10 @@
 #' list_tables("193487687779", "houston")
 #' delete_table("193487687779", "houston", "mtcars")
 #' }
-insert_upload_job <- function(project, dataset, table, values, billing = project) {
+insert_upload_job <- function(project, dataset, table, values,
+                              billing = project,
+                              create_disposition = "CREATE_IF_NEEDED",
+                              write_disposition = "WRITE_APPEND") {
   assert_that(is.string(project), is.string(dataset), is.string(table),
     is.data.frame(values), is.string(billing))
 
@@ -36,7 +40,9 @@ insert_upload_job <- function(project, dataset, table, values, billing = project
           projectId = project,
           datasetId = dataset,
           tableId = table
-        )
+        ),
+        createDisposition = create_disposition,
+        writeDisposition = write_disposition
       )
     )
   )

--- a/man/copy_table.Rd
+++ b/man/copy_table.Rd
@@ -13,13 +13,15 @@ copy_table(src, dest, create_disposition = "CREATE_IF_NEEDED",
 \item{dest}{destination table}
 
 \item{create_disposition}{behavior for table creation if the destination
-already exists. defaults to \code{CREATE_IF_NEEDED}; see
-\url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.createDisposition}
+already exists. defaults to \code{"CREATE_IF_NEEDED"},
+the only other supported value is \code{"CREATE_NEVER"}; see
+\href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.createDisposition}{the API documentation}
 for more information}
 
 \item{write_disposition}{behavior for writing data if the destination already
-exists. defaults to \code{WRITE_EMPTY}; see
-\url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.writeDisposition}
+exists. defaults to \code{"WRITE_EMPTY"}, other possible values are
+\code{"WRITE_TRUNCATE"} and \code{"WRITE_APPEND"}; see
+\href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.writeDisposition}{the API documentation}
 for more information}
 
 \item{project}{project ID to use for the copy job. defaults to the project of

--- a/man/insert_upload_job.Rd
+++ b/man/insert_upload_job.Rd
@@ -4,7 +4,9 @@
 \alias{insert_upload_job}
 \title{Upload data.}
 \usage{
-insert_upload_job(project, dataset, table, values, billing = project)
+insert_upload_job(project, dataset, table, values, billing = project,
+  create_disposition = "CREATE_IF_NEEDED",
+  write_disposition = "WRITE_APPEND")
 }
 \arguments{
 \item{project}{project containing this table}
@@ -16,6 +18,16 @@ insert_upload_job(project, dataset, table, values, billing = project)
 \item{values}{data frame of data to upload}
 
 \item{billing}{project ID to use for billing}
+
+\item{create_disposition}{behavior for table creation if the destination
+already exists. defaults to \code{CREATE_IF_NEEDED}; see
+\url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.createDisposition}
+for more information}
+
+\item{write_disposition}{behavior for writing data if the destination already
+exists. defaults to \code{WRITE_EMPTY}; see
+\url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.writeDisposition}
+for more information}
 }
 \description{
 This sends all of the data inline in the HTTP request so is only suitable

--- a/man/insert_upload_job.Rd
+++ b/man/insert_upload_job.Rd
@@ -20,13 +20,15 @@ insert_upload_job(project, dataset, table, values, billing = project,
 \item{billing}{project ID to use for billing}
 
 \item{create_disposition}{behavior for table creation if the destination
-already exists. defaults to \code{CREATE_IF_NEEDED}; see
-\url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.createDisposition}
+already exists. defaults to \code{"CREATE_IF_NEEDED"},
+the only other supported value is \code{"CREATE_NEVER"}; see
+\href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.createDisposition}{the API documentation}
 for more information}
 
 \item{write_disposition}{behavior for writing data if the destination already
-exists. defaults to \code{WRITE_EMPTY}; see
-\url{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy.writeDisposition}
+exists. defaults to \code{"WRITE_APPEND"}, other possible values are
+\code{"WRITE_TRUNCATE"} and \code{"WRITE_EMPTY"}; see
+\href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.writeDisposition}{the API documentation}
 for more information}
 }
 \description{


### PR DESCRIPTION
analogously to copy_table(), except for the default value for `write_disposition` which is `"WRITE_APPEND"` instead of `"WRITE_EMPTY"`.

Closes #33.