### PR TITLE
Added support for sending the useLegacySql parameter in REST calls.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bigrquery
 Title: An Interface to Google's 'BigQuery' 'API'
 Description: Easily talk to Google's 'BigQuery' database from R.
-Version: 0.3.1.9000
+Version: 0.3.0.9000
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre")),
     person("RStudio", role = "cph")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bigrquery
 Title: An Interface to Google's 'BigQuery' 'API'
 Description: Easily talk to Google's 'BigQuery' database from R.
-Version: 0.3.0.9000
+Version: 0.3.1.9000
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre")),
     person("RStudio", role = "cph")

--- a/R/jobs.r
+++ b/R/jobs.r
@@ -21,6 +21,7 @@
 #' @param default_dataset (optional) default dataset for any table references in
 #'   \code{query}, either as a string in the format used by BigQuery or as a
 #'   list with \code{project_id} and \code{dataset_id} entries
+#' @param useLegacySql (optional) set to \code{FALSE} to enable BigQuery's standard SQL.
 #' @family jobs
 #' @return a job resource list, as documented at
 #'   \url{https://developers.google.com/bigquery/docs/reference/v2/jobs}
@@ -30,14 +31,16 @@
 insert_query_job <- function(query, project, destination_table = NULL,
                              default_dataset = NULL,
                              create_disposition = "CREATE_IF_NEEDED",
-                             write_disposition = "WRITE_EMPTY") {
+                             write_disposition = "WRITE_EMPTY",
+                             useLegacySql = TRUE) {
   assert_that(is.string(project), is.string(query))
 
   url <- sprintf("projects/%s/jobs", project)
   body <- list(
     configuration = list(
       query = list(
-        query = query
+        query = query,
+        useLegacySql = useLegacySql
       )
     )
   )

--- a/R/query.r
+++ b/R/query.r
@@ -29,13 +29,15 @@ query_exec <- function(query, project, destination_table = NULL,
                        page_size = 1e4, max_pages = 10,
                        warn = TRUE,
                        create_disposition = "CREATE_IF_NEEDED",
-                       write_disposition = "WRITE_EMPTY") {
+                       write_disposition = "WRITE_EMPTY",
+                       useLegacySql = TRUE) {
 
   dest <- run_query_job(query = query, project = project,
                         destination_table = destination_table,
                         default_dataset = default_dataset,
                         create_disposition = create_disposition,
-                        write_disposition = write_disposition)
+                        write_disposition = write_disposition,
+                        useLegacySql = useLegacySql)
 
   list_tabledata(dest$projectId, dest$datasetId, dest$tableId,
     page_size = page_size, max_pages = max_pages, warn = warn)
@@ -45,13 +47,15 @@ query_exec <- function(query, project, destination_table = NULL,
 # table for further consumption by the list_tabledata* functions
 run_query_job <- function(query, project, destination_table, default_dataset,
                           create_disposition = "CREATE_IF_NEEDED",
-                          write_disposition = "WRITE_EMPTY") {
+                          write_disposition = "WRITE_EMPTY",
+                          useLegacySql = TRUE) {
   assert_that(is.string(query), is.string(project))
 
   job <- insert_query_job(query, project, destination_table = destination_table,
                           default_dataset = default_dataset,
                           create_disposition = create_disposition,
-                          write_disposition = write_disposition)
+                          write_disposition = write_disposition,
+                          useLegacySql = useLegacySql)
   job <- wait_for(job)
 
   job$configuration$query$destinationTable

--- a/man/insert_query_job.Rd
+++ b/man/insert_query_job.Rd
@@ -6,7 +6,8 @@
 \usage{
 insert_query_job(query, project, destination_table = NULL,
   default_dataset = NULL, create_disposition = "CREATE_IF_NEEDED",
-  write_disposition = "WRITE_EMPTY")
+  write_disposition = "WRITE_EMPTY",
+  useLegacySql = TRUE)
 }
 \arguments{
 \item{query}{SQL query string}
@@ -32,6 +33,8 @@ defaults to \code{"WRITE_EMPTY"}, other possible values are
 \code{"WRITE_TRUNCATE"} and \code{"WRITE_APPEND"}; see
 \href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.writeDisposition}{the API documentation}
 for more information}
+
+\item{useLegacySql}{(optional) set to \code{FALSE} to enable BigQuery's standard SQL.}
 }
 \value{
 a job resource list, as documented at

--- a/man/query_exec.Rd
+++ b/man/query_exec.Rd
@@ -7,7 +7,8 @@
 query_exec(query, project, destination_table = NULL, default_dataset = NULL,
   page_size = 10000, max_pages = 10, warn = TRUE,
   create_disposition = "CREATE_IF_NEEDED",
-  write_disposition = "WRITE_EMPTY")
+  write_disposition = "WRITE_EMPTY",
+  useLegacySql = TRUE)
 }
 \arguments{
 \item{query}{SQL query string}
@@ -41,6 +42,8 @@ defaults to \code{"WRITE_EMPTY"}, other possible values are
 \code{"WRITE_TRUNCATE"} and \code{"WRITE_APPEND"}; see
 \href{https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.query.writeDisposition}{the API documentation}
 for more information}
+
+\item{useLegacySql}{(optional) set to \code{FALSE} to enable BigQuery's standard SQL.}
 }
 \description{
 This is a high-level function that inserts a query job


### PR DESCRIPTION
As mentioned in issue #117, Google recently added support for executing queries written in [standard SQL](https://cloud.google.com/bigquery/sql-reference/) (in addition to legacy SQL). To use it in BigRQuery I just added an argument `useLegacySql` to a few functions and included the value in the REST call.

Thanks for a great package and hope you find this update useful!