### PR TITLE
Fix issue 50 in list_tables function

### DIFF
--- a/R/tables.r
+++ b/R/tables.r
@@ -26,9 +26,14 @@ list_tables <- function(project, dataset, max_results = NULL) {
     query$maxResults <- max_results
   }
   data <- bq_get(url, query = query)$tables
-  do.call("rbind", lapply(data, as.data.frame, row.names = 1L))
-
-  vapply(data, function(x) x$tableReference$tableId, character(1L))
+  tables = tryCatch({
+    do.call("rbind", lapply(data, as.data.frame, row.names = 1L))
+    
+    vapply(data, function(x) x$tableReference$tableId, character(1L))
+  }, error = function(e){
+    unlist(lapply(data, function(x) x$tableReference$tableId))
+  })
+  tables
 }
 
 #' Retrieve table metadata


### PR DESCRIPTION
This commit fixes the issue: https://github.com/rstats-db/bigrquery/issues/50

In my case the dataset contains a view.  

In the line: https://github.com/rstats-db/bigrquery/blob/master/R/tables.r#L28 the variable `data` contains a list with sublists with table attributes:
```
$kind
$id
$tableReference
$type
```
But for the views the list contains additional values:

```
$view
```

with sublist:

```
$view$useLegacySql
```

For this reason it breaks on line 29 because for a table the list contains 4 fields whereas for a view it contains 5.