### PR TITLE
Added query option flattenResults

### DIFF
--- a/R/jobs.r
+++ b/R/jobs.r
@@ -22,6 +22,7 @@
 #'   \code{query}, either as a string in the format used by BigQuery or as a
 #'   list with \code{project_id} and \code{dataset_id} entries
 #' @param useLegacySql (optional) set to \code{FALSE} to enable BigQuery's standard SQL.
+#' @param flattenResults (optional) set to \code{TRUE} to prevent BigQuery from automatically flattening nested and repeated data
 #' @family jobs
 #' @return a job resource list, as documented at
 #'   \url{https://developers.google.com/bigquery/docs/reference/v2/jobs}
@@ -32,7 +33,8 @@ insert_query_job <- function(query, project, destination_table = NULL,
                              default_dataset = NULL,
                              create_disposition = "CREATE_IF_NEEDED",
                              write_disposition = "WRITE_EMPTY",
-                             useLegacySql = TRUE) {
+                             useLegacySql = TRUE,
+                             flattenResults = TRUE) {
   assert_that(is.string(project), is.string(query))
 
   url <- sprintf("projects/%s/jobs", project)
@@ -40,7 +42,8 @@ insert_query_job <- function(query, project, destination_table = NULL,
     configuration = list(
       query = list(
         query = query,
-        useLegacySql = useLegacySql
+        useLegacySql = useLegacySql,
+        flattenResults = flattenResults
       )
     )
   )

--- a/R/query.r
+++ b/R/query.r
@@ -30,14 +30,16 @@ query_exec <- function(query, project, destination_table = NULL,
                        warn = TRUE,
                        create_disposition = "CREATE_IF_NEEDED",
                        write_disposition = "WRITE_EMPTY",
-                       useLegacySql = TRUE) {
+                       useLegacySql = TRUE,
+                       flattenResults = TRUE) {
 
   dest <- run_query_job(query = query, project = project,
                         destination_table = destination_table,
                         default_dataset = default_dataset,
                         create_disposition = create_disposition,
                         write_disposition = write_disposition,
-                        useLegacySql = useLegacySql)
+                        useLegacySql = useLegacySql,
+                        flattenResults = flattenResults)
 
   list_tabledata(dest$projectId, dest$datasetId, dest$tableId,
     page_size = page_size, max_pages = max_pages, warn = warn)
@@ -48,14 +50,16 @@ query_exec <- function(query, project, destination_table = NULL,
 run_query_job <- function(query, project, destination_table, default_dataset,
                           create_disposition = "CREATE_IF_NEEDED",
                           write_disposition = "WRITE_EMPTY",
-                          useLegacySql = TRUE) {
+                          useLegacySql = TRUE,
+                          flattenResults = TRUE) {
   assert_that(is.string(query), is.string(project))
 
   job <- insert_query_job(query, project, destination_table = destination_table,
                           default_dataset = default_dataset,
                           create_disposition = create_disposition,
                           write_disposition = write_disposition,
-                          useLegacySql = useLegacySql)
+                          useLegacySql = useLegacySql,
+                          flattenResults = flattenResults)
   job <- wait_for(job)
 
   job$configuration$query$destinationTable


### PR DESCRIPTION
When using legacy SQL, all data saved to a table is flattened automatically. I added the query configuration option flattenResults so that the user can specify flattenResults = FALSE in order to preserve nesting and repeated fields for query results saved to a destination table.